### PR TITLE
Null coalesce the logger method call

### DIFF
--- a/src/Orleans.Clustering.Kubernetes/KubeGatewayListProvider.cs
+++ b/src/Orleans.Clustering.Kubernetes/KubeGatewayListProvider.cs
@@ -48,7 +48,7 @@ namespace Orleans.Clustering.Kubernetes
             }
             catch (Exception exc)
             {
-                this._logger.LogError(exc, $"Unable to get gateways from Kube objects for cluster {this._clusterId}");
+                this._logger?.LogError(exc, $"Unable to get gateways from Kube objects for cluster {this._clusterId}");
                 throw;
             }
         }


### PR DESCRIPTION
possible null reference exception here since logger is not guaranteed to be instantiated.