### PR TITLE
Added ServicesId in options - Samples

### DIFF
--- a/samples/KubeClient/Program.cs
+++ b/samples/KubeClient/Program.cs
@@ -49,7 +49,7 @@ namespace KubeClient
                 try
                 {
                     client = new ClientBuilder()
-                        .Configure<ClusterOptions>(options => options.ClusterId = "testcluster")
+                        .Configure<ClusterOptions>(options =>  { options.ClusterId = "testcluster"; options.ServiceId = "testservice"; })
                         .UseKubeGatewayListProvider()
                         .ConfigureApplicationParts(parts => parts.AddApplicationPart(typeof(IHello).Assembly).WithReferences())
                         .ConfigureLogging(logging => logging.AddConsole())

--- a/samples/KubeGatewayHost/Program.cs
+++ b/samples/KubeGatewayHost/Program.cs
@@ -40,7 +40,7 @@ namespace KubeGatewayHost
         private static async Task<ISiloHost> StartSilo()
         {
             var builder = new SiloHostBuilder()
-                .Configure<ClusterOptions>(options => options.ClusterId = "testcluster" )
+                .Configure<ClusterOptions>(options =>  { options.ClusterId = "testcluster"; options.ServiceId = "testservice"; })
                 .ConfigureEndpoints(new Random(1).Next(30001, 30100), new Random(1).Next(20001, 20100), listenOnAnyHostAddress: true)
                 .AddMemoryGrainStorageAsDefault()
                 .UseKubeMembership(opt =>

--- a/samples/KubeSiloHost/Program.cs
+++ b/samples/KubeSiloHost/Program.cs
@@ -40,7 +40,7 @@ namespace KubeSiloHost
         private static async Task<ISiloHost> StartSilo()
         {
             var builder = new SiloHostBuilder()
-                .Configure<ClusterOptions>(options => options.ClusterId = "testcluster")
+                .Configure<ClusterOptions>(options =>  { options.ClusterId = "testcluster"; options.ServiceId = "testservice"; })
                 .ConfigureEndpoints(new Random(1).Next(10001, 10100), new Random(1).Next(20001, 20100))
                 .UseKubeMembership(opt =>
                 {


### PR DESCRIPTION
Added  value for ServicesId in options object.

resolved error "Orleans.Runtime.OrleansConfigurationException: Configuration for ClusterOptions is invalid. A non-empty value for ServiceId is required."