### PR TITLE
Changed X509 to read directly from file

### DIFF
--- a/src/Orleans.Clustering.Kubernetes/API/KubeClient.cs
+++ b/src/Orleans.Clustering.Kubernetes/API/KubeClient.cs
@@ -82,6 +82,7 @@ namespace Orleans.Clustering.Kubernetes.API
             var endpointUri = new Uri(string.IsNullOrWhiteSpace(apiEndpoint) ? IN_CLUSTER_KUBE_ENDPOINT : apiEndpoint);
 
             var certificateData = certificate;
+            var isCertificateLoaded = false;
 
             if (string.IsNullOrWhiteSpace(certificateData))
             {
@@ -89,7 +90,9 @@ namespace Orleans.Clustering.Kubernetes.API
 
                 if (File.Exists(rootCertificateFilePath))
                 {
-                    certificateData = File.ReadAllText(rootCertificateFilePath);
+                    this.RootCertificate = new X509Certificate2(rootCertificateFilePath);
+                    isCertificateLoaded = true;
+
                 }
                 else
                 {
@@ -97,7 +100,7 @@ namespace Orleans.Clustering.Kubernetes.API
                 }
             }
 
-            if (!string.IsNullOrWhiteSpace(certificateData))
+            if (!isCertificateLoaded && !string.IsNullOrWhiteSpace(certificateData))
             {
                 certificateData = certificateData
                     .Replace(BEGIN_CERT_LINE, string.Empty)

--- a/src/Orleans.Clustering.Kubernetes/API/KubeClient.cs
+++ b/src/Orleans.Clustering.Kubernetes/API/KubeClient.cs
@@ -82,7 +82,7 @@ namespace Orleans.Clustering.Kubernetes.API
             var endpointUri = new Uri(string.IsNullOrWhiteSpace(apiEndpoint) ? IN_CLUSTER_KUBE_ENDPOINT : apiEndpoint);
 
             var certificateData = certificate;
-            var isCertificateLoaded = false;
+            var isRootCertificateLoaded = false;
 
             if (string.IsNullOrWhiteSpace(certificateData))
             {
@@ -91,7 +91,7 @@ namespace Orleans.Clustering.Kubernetes.API
                 if (File.Exists(rootCertificateFilePath))
                 {
                     this.RootCertificate = new X509Certificate2(rootCertificateFilePath);
-                    isCertificateLoaded = true;
+                    isRootCertificateLoaded = true;
 
                 }
                 else
@@ -100,7 +100,7 @@ namespace Orleans.Clustering.Kubernetes.API
                 }
             }
 
-            if (!isCertificateLoaded && !string.IsNullOrWhiteSpace(certificateData))
+            if (!isRootCertificateLoaded && !string.IsNullOrWhiteSpace(certificateData))
             {
                 certificateData = certificateData
                     .Replace(BEGIN_CERT_LINE, string.Empty)

--- a/test/Orleans.Clustering.Kubernetes.Test/IgnoreInsidePodFact.cs
+++ b/test/Orleans.Clustering.Kubernetes.Test/IgnoreInsidePodFact.cs
@@ -1,0 +1,16 @@
+using System.IO;
+using Xunit;
+
+namespace Orleans.Clustering.Kubernetes.Test
+{
+    public sealed class IgnoreInsidePodFact : FactAttribute
+    {
+        private const string rootCertificatePath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt";
+
+        public IgnoreInsidePodFact() {
+            if (File.Exists(rootCertificatePath)) {
+                this.Skip = "Ignore when running inside a Pod";
+            }
+        }
+    }
+}

--- a/test/Orleans.Clustering.Kubernetes.Test/KubeClientTests.cs
+++ b/test/Orleans.Clustering.Kubernetes.Test/KubeClientTests.cs
@@ -6,31 +6,49 @@ namespace Orleans.Clustering.Kubernetes.Test
     public class KubeClientTests
     {
         [Fact]
-        public void RootCertificateConstructedFromCertificateParameterWhenProvided()
+        public void RootCertificateConstructedFromCertificateParameterWhenProvided_ReturnsValidRootCertificate()
         {
             const string certificate =
                 @"-----BEGIN CERTIFICATE-----
-MIIC+zCCAeOgAwIBAgIJAIC+9fYZ2Xu1MA0GCSqGSIb3DQEBBQUAMBQxEjAQBgNV
-BAMMCWxvY2FsaG9zdDAeFw0xOTEwMDYxMjE2MDFaFw0yOTEwMDMxMjE2MDFaMBQx
-EjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
-ggEBALWQJx3SZiW4plqZSpjz0PFU9QR3IcK27Du6Tr7wlBErfdEdUJ/TuC72EFWF
-yR4/pCWfmiIwZnkxJGVwjaRbi0B/hza9ifbr+7uqxlVYZUN8lt5UtFpFuRvs5g69
-uEutlJx/dUmvPQOoW1DzmqUAKlum8vzhcRZaSYKtWnLyGb0ec20B6Sa1nrEQtW0h
-LofTJ6JvTk+MZmCTzIfeBsNz2iLDdSYDr7rlP/lWkJh+XjzFPBCDJILP1JUwPOrF
-AUpwuejqm4BecjLlquPN8Lqpf7Zp1X5WCU81AQyuHXlv3FdayL8VTJGhoTRpCrvU
-s5WnZgrOq3IAAk8agme+JbL6NqUCAwEAAaNQME4wHQYDVR0OBBYEFMNqhycFj+RF
-LmxsR4EMu0mpnJL3MB8GA1UdIwQYMBaAFMNqhycFj+RFLmxsR4EMu0mpnJL3MAwG
-A1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBADqFsU9l2PJsCiGtU4C3tsAz
-LwHUEvOHRjXFU9bN8LApyUIGo9qsTXLyLOLv0nIrDq1gELoKgAvuD1lbnWbcTcCG
-q5/f9ttB6cT513ffm4GBTenTIHSq+FFZT6A2Mwko1+3Man2vznWjl/HF5eQ6PS7U
-by/z6A9Nm1Rw8Uu541odWU8/KQCSO9c/Yo+1GsDIDj5lMfLRl21Mp/lPGbGGuGu5
-iMRH8QYi7YQZ2GLbaLxSY7edJlmFGYTWWV9C9jKE3s/WMaJ6Dz7NXrQM4YOE00V8
-bzUuNqNBUDUhQGQDOCem29+nhKT+GPWqDt2YRDFj80UJ5wt+ljddmlVhtRS/YgY=
------END CERTIFICATE-----";
+        MIIC+zCCAeOgAwIBAgIJAIC+9fYZ2Xu1MA0GCSqGSIb3DQEBBQUAMBQxEjAQBgNV
+        BAMMCWxvY2FsaG9zdDAeFw0xOTEwMDYxMjE2MDFaFw0yOTEwMDMxMjE2MDFaMBQx
+        EjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
+        ggEBALWQJx3SZiW4plqZSpjz0PFU9QR3IcK27Du6Tr7wlBErfdEdUJ/TuC72EFWF
+        yR4/pCWfmiIwZnkxJGVwjaRbi0B/hza9ifbr+7uqxlVYZUN8lt5UtFpFuRvs5g69
+        uEutlJx/dUmvPQOoW1DzmqUAKlum8vzhcRZaSYKtWnLyGb0ec20B6Sa1nrEQtW0h
+        LofTJ6JvTk+MZmCTzIfeBsNz2iLDdSYDr7rlP/lWkJh+XjzFPBCDJILP1JUwPOrF
+        AUpwuejqm4BecjLlquPN8Lqpf7Zp1X5WCU81AQyuHXlv3FdayL8VTJGhoTRpCrvU
+        s5WnZgrOq3IAAk8agme+JbL6NqUCAwEAAaNQME4wHQYDVR0OBBYEFMNqhycFj+RF
+        LmxsR4EMu0mpnJL3MB8GA1UdIwQYMBaAFMNqhycFj+RFLmxsR4EMu0mpnJL3MAwG
+        A1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBADqFsU9l2PJsCiGtU4C3tsAz
+        LwHUEvOHRjXFU9bN8LApyUIGo9qsTXLyLOLv0nIrDq1gELoKgAvuD1lbnWbcTcCG
+        q5/f9ttB6cT513ffm4GBTenTIHSq+FFZT6A2Mwko1+3Man2vznWjl/HF5eQ6PS7U
+        by/z6A9Nm1Rw8Uu541odWU8/KQCSO9c/Yo+1GsDIDj5lMfLRl21Mp/lPGbGGuGu5
+        iMRH8QYi7YQZ2GLbaLxSY7edJlmFGYTWWV9C9jKE3s/WMaJ6Dz7NXrQM4YOE00V8
+        bzUuNqNBUDUhQGQDOCem29+nhKT+GPWqDt2YRDFj80UJ5wt+ljddmlVhtRS/YgY=
+        -----END CERTIFICATE-----";
 
             var client = new KubeClient(null, certificate: certificate);
 
             Assert.NotNull(client.RootCertificate);
+        }
+
+        [Fact]
+        public void RootCertificateConstructedFromCertificateWithoutHeaders_ReturnsValidRootCertificate()
+        {
+            const string certificate = @"MIIC+zCCAeOgAwIBAgIJAIC+9fYZ2Xu1MA0GCSqGSIb3DQEBBQUAMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDAeFw0xOTEwMDYxMjE2MDFaFw0yOTEwMDMxMjE2MDFaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALWQJx3SZiW4plqZSpjz0PFU9QR3IcK27Du6Tr7wlBErfdEdUJ/TuC72EFWFyR4/pCWfmiIwZnkxJGVwjaRbi0B/hza9ifbr+7uqxlVYZUN8lt5UtFpFuRvs5g69uEutlJx/dUmvPQOoW1DzmqUAKlum8vzhcRZaSYKtWnLyGb0ec20B6Sa1nrEQtW0hLofTJ6JvTk+MZmCTzIfeBsNz2iLDdSYDr7rlP/lWkJh+XjzFPBCDJILP1JUwPOrFAUpwuejqm4BecjLlquPN8Lqpf7Zp1X5WCU81AQyuHXlv3FdayL8VTJGhoTRpCrvUs5WnZgrOq3IAAk8agme+JbL6NqUCAwEAAaNQME4wHQYDVR0OBBYEFMNqhycFj+RFLmxsR4EMu0mpnJL3MB8GA1UdIwQYMBaAFMNqhycFj+RFLmxsR4EMu0mpnJL3MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBADqFsU9l2PJsCiGtU4C3tsAzLwHUEvOHRjXFU9bN8LApyUIGo9qsTXLyLOLv0nIrDq1gELoKgAvuD1lbnWbcTcCGq5/f9ttB6cT513ffm4GBTenTIHSq+FFZT6A2Mwko1+3Man2vznWjl/HF5eQ6PS7Uby/z6A9Nm1Rw8Uu541odWU8/KQCSO9c/Yo+1GsDIDj5lMfLRl21Mp/lPGbGGuGu5iMRH8QYi7YQZ2GLbaLxSY7edJlmFGYTWWV9C9jKE3s/WMaJ6Dz7NXrQM4YOE00V8bzUuNqNBUDUhQGQDOCem29+nhKT+GPWqDt2YRDFj80UJ5wt+ljddmlVhtRS/YgY=";
+
+            var client = new KubeClient(null, certificate: certificate);
+
+            Assert.NotNull(client.RootCertificate);
+        }
+
+        [IgnoreInsidePodFact]
+        public void RootCertificateMissing_ReturnsNullRootCertificate()
+        {
+            var client = new KubeClient(null);
+
+            Assert.Null(client.RootCertificate);
         }
     }
 }


### PR DESCRIPTION
* Changed Base64 decode to X509Certificate2 file import functionality to support CA certificates with multiple public certificates in /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
* Added new test cases