### PR TITLE
V2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -288,3 +288,5 @@ __pycache__/
 *.odx.cs
 *.xsd.cs
 .DS_Store
+
+**/output

--- a/samples/Definitions/Client-ServiceAccount.yaml
+++ b/samples/Definitions/Client-ServiceAccount.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: orleansclient
+    namespace: kubetest
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: orleansclient
+rules:
+    - apiGroups:
+          - orleans.dot.net
+      resources:
+          - silos
+          - clusterversions
+      verbs:
+          - get
+          - list
+          - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: orleansclient
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: orleansclient
+subjects:
+    - kind: ServiceAccount
+      name: orleansclient
+      namespace: kubetest

--- a/samples/Definitions/Client.yaml
+++ b/samples/Definitions/Client.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: orleans-client
+    labels:
+        app: kubeclient
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: kubeclient
+    template:
+        metadata:
+            labels:
+                app: kubeclient
+        spec:
+            serviceAccountName: orleansclient
+            containers:
+                - name: orleansclient
+                  image: kubeclient:latest
+                  imagePullPolicy: Never

--- a/samples/Definitions/Gateway.yaml
+++ b/samples/Definitions/Gateway.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: orleans-gateway
+    labels:
+        app: kubegateway
+spec:
+    replicas: 2
+    selector:
+        matchLabels:
+            app: kubegateway
+    template:
+        metadata:
+            labels:
+                app: kubegateway
+        spec:
+            serviceAccountName: orleanssilo
+            containers:
+                - name: orleanssilo
+                  image: kubegateway:latest
+                  imagePullPolicy: Never

--- a/samples/Definitions/Silo-ServiceAccount.yaml
+++ b/samples/Definitions/Silo-ServiceAccount.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: orleanssilo
+    namespace: kubetest
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: orleanssilo
+rules:
+    - apiGroups:
+          - orleans.dot.net
+      resources:
+          - silos
+          - clusterversions
+      verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: orleanssilo
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: orleanssilo
+subjects:
+    - kind: ServiceAccount
+      name: orleanssilo
+      namespace: kubetest

--- a/samples/Definitions/Silo.yaml
+++ b/samples/Definitions/Silo.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: orleans-silo
+    labels:
+        app: kubesilo
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: kubesilo
+    template:
+        metadata:
+            labels:
+                app: kubesilo
+        spec:
+            serviceAccountName: orleanssilo
+            containers:
+                - name: orleanssilo
+                  image: kubesilo:latest
+                  imagePullPolicy: Never

--- a/src/Orleans.Clustering.Kubernetes/ClusteringExtensions.cs
+++ b/src/Orleans.Clustering.Kubernetes/ClusteringExtensions.cs
@@ -64,7 +64,10 @@ namespace Orleans.Clustering.Kubernetes
             return builder.ConfigureServices((ctx, services) =>
             {
                 services.AddOptions<KubeGatewayOptions>();
-                services.Configure<KubeGatewayOptions>(configureOptions);
+                if (configureOptions != null)
+                {
+                    services.Configure<KubeGatewayOptions>(configureOptions);
+                }
 
                 KubernetesClientConfiguration config = default;
 

--- a/src/Orleans.Clustering.Kubernetes/KubeMembershipTable.cs
+++ b/src/Orleans.Clustering.Kubernetes/KubeMembershipTable.cs
@@ -36,7 +36,8 @@ namespace Orleans.Clustering.Kubernetes
 
         public async Task InitializeMembershipTable(bool tryInitTableVersion)
         {
-            this._namespace = await this.GetNamespace();
+            this._namespace = this.GetNamespace();
+            this._logger.LogInformation($"Using Kubernetes namespace: {this._namespace}.");
 
             if (tryInitTableVersion)
             {
@@ -373,7 +374,10 @@ namespace Orleans.Clustering.Kubernetes
                 catch (HttpOperationException ex)
                 {
                     if (ex.Response.StatusCode != HttpStatusCode.NotFound)
+                    {
+                        this._logger.LogError(ex, $"Unable to initialize cluster version: {ex.Message}.");
                         throw;
+                    }
                 }
 
                 if (version == null)
@@ -549,27 +553,14 @@ namespace Orleans.Clustering.Kubernetes
             }
         }
 
-        private async Task<string> GetNamespace()
+        private string GetNamespace()
         {
             var namespaceFilePath = Path.Combine(Constants.SERVICE_ACCOUNT_PATH, Constants.SERVICE_ACCOUNT_NAMESPACE_FILENAME);
-            if (File.Exists(namespaceFilePath))
-            {
-                using var sourceStream = new FileStream(namespaceFilePath,
-                    FileMode.Open, FileAccess.Read, FileShare.Read,
-                    bufferSize: 4096, useAsync: true);
+            if (!File.Exists(namespaceFilePath)) return Constants.ORLEANS_NAMESPACE;
 
-                var sb = new StringBuilder();
+            var ns = File.ReadAllText(namespaceFilePath);
 
-                byte[] buffer = new byte[0x1000];
-                int numRead;
-                while ((numRead = await sourceStream.ReadAsync(buffer, 0, buffer.Length)) != 0)
-                {
-                    string text = Encoding.Unicode.GetString(buffer, 0, numRead);
-                    sb.Append(text);
-                }
-
-                return sb.ToString();
-            }
+            if (!string.IsNullOrWhiteSpace(ns)) return ns;
 
             this._logger?.LogWarning(
                 "Namespace file {namespaceFilePath} wasn't found. Are we running in a pod? If you are running unit tests outside a pod, please create the test namespace '{namespace}'.",


### PR DESCRIPTION
- Update to Orleans 3.2
- Dropped custom Kubernetes Client
- Using official [KubernetecClient](https://github.com/kubernetes-client/csharp)
- Removed unused options from the configure methods simplifying the configuration (see README)
- Samples updated

**Breaking changes:**
> This release requires Kubernetes version 1.16 or superior.
> This release requires publishing the CRDs again.