### PR TITLE
Upgrade Orleans to 3.5.1 and Kubernetes client to match

### DIFF
--- a/samples/HelloWorld.Grains/HelloWorld.Grains.csproj
+++ b/samples/HelloWorld.Grains/HelloWorld.Grains.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="3.5.1" />
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/HelloWorld.Interfaces/HelloWorld.Interfaces.csproj
+++ b/samples/HelloWorld.Interfaces/HelloWorld.Interfaces.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="3.5.1" />
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.5.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/KubeClient/KubeClient.csproj
+++ b/samples/KubeClient/KubeClient.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Orleans.Core" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="3.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/KubeGatewayHost/KubeGatewayHost.csproj
+++ b/samples/KubeGatewayHost/KubeGatewayHost.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="3.5.1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/KubeSiloHost/KubeSiloHost.csproj
+++ b/samples/KubeSiloHost/KubeSiloHost.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.1" />
-    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="3.5.1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Orleans.Clustering.Kubernetes/Orleans.Clustering.Kubernetes.csproj
+++ b/src/Orleans.Clustering.Kubernetes/Orleans.Clustering.Kubernetes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
@@ -23,9 +23,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Core" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.2.0" />
-    <PackageReference Include="KubernetesClient" Version="2.0.25" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="3.5.1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.5.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="KubernetesClient" Version="4.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+    <PackageReference Include="KubernetesClient" Version="6.0.19" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Orleans.Clustering.Kubernetes.Test/Orleans.Clustering.Kubernetes.Test.csproj
+++ b/test/Orleans.Clustering.Kubernetes.Test/Orleans.Clustering.Kubernetes.Test.csproj
@@ -8,14 +8,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.2.0">
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.5.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.Server" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="3.5.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />
-    <PackageReference Include="KubernetesClient" Version="2.0.25" />
+    <PackageReference Include="KubernetesClient" Version="6.0.19" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR upgrades the Orleans core dependencies and the Kubernetes client to match, as well as adding multi-targeting (to match Orleans itself again).

Fixes #55