### PR TITLE
fix: added .NET 8.0 compatibilty

### DIFF
--- a/src/Orleans.Clustering.Kubernetes/Orleans.Clustering.Kubernetes.csproj
+++ b/src/Orleans.Clustering.Kubernetes/Orleans.Clustering.Kubernetes.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary

Since **Orleans 10** supports both `net8.0` and `net10.0`, this PR updates the project to be compatible with both target frameworks when using the `Orleans.Clustering.Kubernetes` NuGet package.

## Changes

- Added multi-targeting support for:
  - `net8.0`
  - `net10.0`
- Ensured compatibility with `Orleans.Clustering.Kubernetes` across both frameworks.
- Kept sample projects targeting `net10.0`, as this is the preferred and forward-looking runtime.

## Rationale

Although `net8.0` is supported by Orleans 10, `net10.0` remains the recommended target going forward. Maintaining compatibility with both frameworks allows:

- Broader adoption for teams still on .NET 8
- Forward compatibility for teams standardizing on .NET 10
- Smoother upgrade paths

## Impact

- No breaking changes expected.
- Consumers can now choose either `net8.0` or `net10.0`.
- Sample projects remain aligned with the preferred runtime (`net10.0`).